### PR TITLE
Add admin publisher management

### DIFF
--- a/src/public/admin.html
+++ b/src/public/admin.html
@@ -170,9 +170,11 @@
     // Update channels list
     function updateChannelsList(channelIds) {
       channels = channelIds;
-      
+
       if (channelIds.length === 0) {
         channelsList.innerHTML = '<p>No active channels</p>';
+        // still refresh publisher options in case all channels were removed
+        updatePublishersList(publishers);
         return;
       }
       
@@ -192,6 +194,9 @@
       
       html += '</table>';
       channelsList.innerHTML = html;
+
+      // Refresh publisher dropdowns to include new channel list
+      updatePublishersList(publishers);
     }
     
     // Update subscribers list

--- a/src/public/admin.html
+++ b/src/public/admin.html
@@ -40,6 +40,13 @@
         <p>No subscribers</p>
       </div>
     </div>
+
+    <div>
+      <h2>Publishers</h2>
+      <div id="publishersList">
+        <p>No publishers</p>
+      </div>
+    </div>
   </div>
 
   <script src="/js/common.js"></script>
@@ -49,10 +56,12 @@
     const createChannelForm = document.getElementById('createChannelForm');
     const channelsList = document.getElementById('channelsList');
     const subscribersList = document.getElementById('subscribersList');
+    const publishersList = document.getElementById('publishersList');
     
     // State
     let channels = [];
     let subscribers = {};
+    let publishers = [];
     
     // Initialize
     document.addEventListener('DOMContentLoaded', () => {
@@ -81,8 +90,9 @@
             rtpCapabilities = data;
             // Request channel list
             sendMessage('get-channels');
-            // Request subscribers list
+            // Request subscribers and publishers list
             sendMessage('admin-get-channels-subscribers');
+            sendMessage('admin-get-publishers');
             break;
             
           case 'channel-list':
@@ -92,6 +102,10 @@
             
           case 'channels-subscribers':
             updateSubscribersList(data);
+            break;
+
+          case 'publishers-list':
+            updatePublishersList(data);
             break;
             
           case 'channel-created':
@@ -106,6 +120,12 @@
             
           case 'subscriber-removed':
             updateStatus(`Subscriber removed from channel ${data.channelId}`, 'success');
+            sendMessage('admin-get-channels-subscribers');
+            break;
+
+          case 'publisher-channel-changed':
+            updateStatus(`Publisher moved to ${data.newChannelId}`, 'success');
+            sendMessage('admin-get-publishers');
             sendMessage('admin-get-channels-subscribers');
             break;
             
@@ -213,12 +233,57 @@
       
       subscribersList.innerHTML = html;
     }
+
+    // Update publishers list
+    function updatePublishersList(data) {
+      publishers = data;
+
+      if (!data || data.length === 0) {
+        publishersList.innerHTML = '<p>No publishers</p>';
+        return;
+      }
+
+      let html = '<table>';
+      html += '<tr><th>Publisher ID</th><th>Channel</th><th>Action</th></tr>';
+
+      data.forEach(pub => {
+        const options = channels
+          .map(c => `<option value="${c}" ${c === pub.channelId ? 'selected' : ''}>${c}</option>`)
+          .join('');
+        html += `
+          <tr>
+            <td>${pub.id}</td>
+            <td>
+              <select id="channelSelect_${pub.id}">${options}</select>
+            </td>
+            <td>
+              <button onclick="changePublisherChannel('${pub.id}')">Change</button>
+            </td>
+          </tr>
+        `;
+      });
+
+      html += '</table>';
+      publishersList.innerHTML = html;
+    }
+
+    // Change publisher channel
+    function changePublisherChannel(publisherId) {
+      const select = document.getElementById('channelSelect_' + publisherId);
+      const newChannelId = select ? select.value : '';
+      if (!newChannelId) {
+        updateStatus('Please select a channel', 'error');
+        return;
+      }
+      sendMessage('admin-change-publisher-channel', { publisherId, newChannelId });
+    }
     
     // Refresh data periodically
     setInterval(() => {
       if (socket && socket.readyState === WebSocket.OPEN) {
         sendMessage('get-channels');
         sendMessage('admin-get-channels-subscribers');
+        sendMessage('admin-get-publishers');
       }
     }, 5000);
   </script>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -139,6 +139,10 @@
             handleConsumerCreated(data);
             break;
 
+          case 'waiting-for-publisher':
+            updateStatus('Waiting for publisher...', 'info');
+            break;
+
           case 'producer-stopped':
             handleProducerStopped(data.producerId);
             break;
@@ -194,10 +198,13 @@
         // Request transport creation
         selectedChannel = channelId;
         updateStatus(`Joining channel "${channelId}"...`, 'info');
-        sendMessage('create-listener-transport', { 
-          channelId, 
-          displayName 
+        sendMessage('create-listener-transport', {
+          channelId,
+          displayName
         });
+        joinForm.classList.add('hidden');
+        listenerControls.classList.remove('hidden');
+        currentChannelSpan.textContent = channelId;
       } catch (error) {
         console.error('Error joining channel:', error);
         updateStatus('Error joining channel: ' + error.message, 'error');

--- a/src/public/publisher.html
+++ b/src/public/publisher.html
@@ -64,6 +64,7 @@
     let audioMeter = null;
     let producerId = null;
     let meterUpdateInterval = null;
+    let isBroadcasting = false;
     
     // Initialize
     document.addEventListener('DOMContentLoaded', async () => {
@@ -138,6 +139,7 @@
           updateStatus('Broadcasting started!', 'success');
           startBroadcastBtn.disabled = true;
           stopBroadcastBtn.disabled = false;
+          isBroadcasting = true;
           break;
           
         case 'error':
@@ -153,9 +155,15 @@
         case 'admin-channel-changed':
           updateStatus(`Channel changed by admin to ${payload.channelId}`, 'info');
           if (selectedChannel !== payload.channelId) {
-            stopBroadcasting();
+            const wasBroadcasting = isBroadcasting;
+            if (wasBroadcasting) {
+              stopBroadcasting();
+            }
             selectedChannel = payload.channelId;
             updateChannelsList(channels);
+            if (wasBroadcasting) {
+              startBroadcasting();
+            }
           }
           break;
           
@@ -235,10 +243,19 @@
     
     // Select a channel
     function selectChannel(channelId) {
+      const wasBroadcasting = isBroadcasting;
+      if (wasBroadcasting) {
+        stopBroadcasting();
+      }
+
       selectedChannel = channelId;
       updateStatus(`Channel "${channelId}" selected`, 'success');
       publisherControls.classList.remove('hidden');
       updateChannelsList(channels);
+
+      if (wasBroadcasting) {
+        startBroadcasting();
+      }
     }
     
     // Start broadcasting
@@ -423,7 +440,9 @@
       
       // Reset producer ID
       producerId = null;
-      
+
+      isBroadcasting = false;
+
       updateStatus('Broadcasting stopped', 'info');
     }
     

--- a/src/public/publisher.html
+++ b/src/public/publisher.html
@@ -149,6 +149,15 @@
           updateStatus(`Disconnected: ${payload.reason}`, 'error');
           stopBroadcasting();
           break;
+
+        case 'admin-channel-changed':
+          updateStatus(`Channel changed by admin to ${payload.channelId}`, 'info');
+          if (selectedChannel !== payload.channelId) {
+            stopBroadcasting();
+            selectedChannel = payload.channelId;
+            updateChannelsList(channels);
+          }
+          break;
           
         default:
           console.log('Unknown action:', action);

--- a/src/server.js
+++ b/src/server.js
@@ -579,17 +579,7 @@ fastify.register(async function (fastify) {
             }
 
             const listenerChannel = channels.get(data.channelId);
-            
-            // Check if channel has a producer
-            if (listenerChannel.producers.size === 0) {
-              fastify.log.warn(`Client ${clientId} tried to join channel ${data.channelId} with no active publisher`);
-              connection.send(JSON.stringify({
-                action: 'error',
-                data: { message: 'No active publisher in this channel' }
-              }));
-              break;
-            }
-            
+
             try {
               // Create transport
               fastify.log.info(`Creating listener transport for client ${clientId}`);
@@ -672,11 +662,9 @@ fastify.register(async function (fastify) {
             }
             
             if (consumerChannel.producers.size === 0) {
-              fastify.log.warn(`No active publisher in channel ${clientInfo.channelId}`);
-              connection.send(JSON.stringify({
-                action: 'error',
-                data: { message: 'No active publisher in this channel' }
-              }));
+              fastify.log.info(`Listener ${clientId} waiting for publisher in channel ${clientInfo.channelId}`);
+              clientInfo.rtpCapabilities = data.rtpCapabilities;
+              connection.send(JSON.stringify({ action: 'waiting-for-publisher' }));
               break;
             }
 


### PR DESCRIPTION
## Summary
- list active publishers on admin page
- allow admin to move publishers between channels
- notify publishers when their channel is changed

## Testing
- `npm run bundle:mediasoup` *(fails: Cannot find package 'esbuild')*
- `npm install` *(fails: unable to download dependencies)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849347aef60833196a16614e9573722