### PR TITLE
Add admin↔publisher chat and in-page publisher channel monitoring

### DIFF
--- a/src/public/js/floating-chat-widget.js
+++ b/src/public/js/floating-chat-widget.js
@@ -1,0 +1,347 @@
+(function () {
+  if (window.SoundcastFloatingChat) return;
+
+  const STYLE_ID = 'soundcast-floating-chat-widget-style';
+
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+      .sc-chat-fab {
+        position: fixed;
+        right: 20px;
+        bottom: 20px;
+        z-index: 1200;
+        border: none;
+        border-radius: 999px;
+        background: #2563eb;
+        color: #fff;
+        font-weight: 700;
+        padding: 12px 16px;
+        cursor: pointer;
+        box-shadow: 0 8px 24px rgba(37, 99, 235, 0.35);
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .sc-chat-fab:hover {
+        background: #1d4ed8;
+      }
+
+      .sc-chat-badge {
+        min-width: 18px;
+        height: 18px;
+        border-radius: 999px;
+        background: #ef4444;
+        color: #fff;
+        font-size: 11px;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 0 5px;
+        box-sizing: border-box;
+      }
+
+      .sc-chat-panel {
+        position: fixed;
+        right: 20px;
+        bottom: 74px;
+        width: 360px;
+        max-width: calc(100vw - 24px);
+        max-height: min(500px, calc(100vh - 100px));
+        border: 1px solid #cbd5e0;
+        border-radius: 12px;
+        padding: 12px;
+        background: #f8fafc;
+        display: none;
+        z-index: 1200;
+        box-shadow: 0 14px 40px rgba(0, 0, 0, 0.2);
+      }
+
+      .sc-chat-panel.open {
+        display: block;
+      }
+
+      .sc-chat-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        margin-bottom: 8px;
+      }
+
+      .sc-chat-title {
+        font-weight: 700;
+        font-size: 14px;
+        color: #1f2937;
+      }
+
+      .sc-chat-close {
+        border: none;
+        background: transparent;
+        font-size: 18px;
+        line-height: 1;
+        cursor: pointer;
+        color: #4a5568;
+        padding: 2px 4px;
+      }
+
+      .sc-chat-log {
+        max-height: 320px;
+        overflow-y: auto;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 6px;
+        padding: 10px;
+        margin: 8px 0;
+        font-size: 13px;
+      }
+
+      .sc-chat-composer {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+
+      .sc-chat-input {
+        flex: 1;
+        min-width: 0;
+        width: auto;
+        margin: 0;
+      }
+
+      .sc-chat-send {
+        width: auto;
+        min-width: 88px;
+        margin: 0;
+        padding: 10px 16px;
+        font-size: 14px;
+        line-height: 1.2;
+        flex: 0 0 auto;
+      }
+
+      @media (max-width: 600px) {
+        .sc-chat-fab {
+          right: 12px;
+          bottom: 12px;
+        }
+
+        .sc-chat-panel {
+          right: 12px;
+          left: 12px;
+          width: auto;
+          bottom: 64px;
+          max-width: none;
+        }
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function createChatWidget(options = {}) {
+    injectStyles();
+
+    const config = {
+      buttonLabel: options.buttonLabel || 'Chat',
+      title: options.title || 'Chat',
+      inputPlaceholder: options.inputPlaceholder || 'Type a message...',
+      emptyMessage: options.emptyMessage || 'No messages yet.',
+      sendButtonLabel: options.sendButtonLabel || 'Send',
+      renderMessage: options.renderMessage || ((msg) => (msg && msg.text) ? String(msg.text) : ''),
+      onSend: typeof options.onSend === 'function' ? options.onSend : async () => true
+    };
+
+    const root = document.createElement('div');
+    root.className = 'sc-chat-widget';
+
+    const fab = document.createElement('button');
+    fab.className = 'sc-chat-fab';
+    fab.type = 'button';
+    fab.textContent = config.buttonLabel;
+
+    const badge = document.createElement('span');
+    badge.className = 'sc-chat-badge';
+    badge.textContent = '0';
+    fab.appendChild(badge);
+
+    const panel = document.createElement('div');
+    panel.className = 'sc-chat-panel';
+
+    const header = document.createElement('div');
+    header.className = 'sc-chat-header';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'sc-chat-title';
+    titleEl.textContent = config.title;
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'sc-chat-close';
+    closeBtn.type = 'button';
+    closeBtn.setAttribute('aria-label', 'Close chat panel');
+    closeBtn.textContent = '\u00D7';
+
+    const log = document.createElement('div');
+    log.className = 'sc-chat-log';
+    log.textContent = config.emptyMessage;
+
+    const composer = document.createElement('div');
+    composer.className = 'sc-chat-composer';
+
+    const input = document.createElement('input');
+    input.className = 'form-input sc-chat-input';
+    input.type = 'text';
+    input.placeholder = config.inputPlaceholder;
+
+    const sendBtn = document.createElement('button');
+    sendBtn.className = 'btn btn-primary sc-chat-send';
+    sendBtn.type = 'button';
+    sendBtn.textContent = config.sendButtonLabel;
+
+    header.appendChild(titleEl);
+    header.appendChild(closeBtn);
+    composer.appendChild(input);
+    composer.appendChild(sendBtn);
+    panel.appendChild(header);
+    panel.appendChild(log);
+    panel.appendChild(composer);
+    root.appendChild(fab);
+    root.appendChild(panel);
+    document.body.appendChild(root);
+
+    function applyPosition(position) {
+      if (!position || typeof position !== 'object') return;
+      if (typeof position.right === 'number') {
+        fab.style.right = `${position.right}px`;
+        panel.style.right = `${position.right}px`;
+      }
+      if (typeof position.left === 'number') {
+        fab.style.left = `${position.left}px`;
+        panel.style.left = `${position.left}px`;
+      }
+      if (typeof position.fabBottom === 'number') {
+        fab.style.bottom = `${position.fabBottom}px`;
+      }
+      if (typeof position.panelBottom === 'number') {
+        panel.style.bottom = `${position.panelBottom}px`;
+      }
+    }
+
+    applyPosition(options.position);
+
+    let isOpen = false;
+    let unreadCount = 0;
+    let messages = [];
+    let enabled = true;
+    let emptyMessage = config.emptyMessage;
+
+    function syncUnreadBadge() {
+      if (unreadCount > 0) {
+        badge.style.display = 'inline-flex';
+        badge.textContent = String(Math.min(unreadCount, 99));
+      } else {
+        badge.style.display = 'none';
+      }
+    }
+
+    function renderMessages() {
+      if (!messages || messages.length === 0) {
+        log.textContent = emptyMessage;
+        return;
+      }
+      log.innerHTML = messages.map((msg) => config.renderMessage(msg)).join('');
+      log.scrollTop = log.scrollHeight;
+    }
+
+    function setOpen(open) {
+      isOpen = Boolean(open);
+      if (isOpen) {
+        panel.classList.add('open');
+        unreadCount = 0;
+        syncUnreadBadge();
+        input.focus();
+      } else {
+        panel.classList.remove('open');
+      }
+    }
+
+    async function send() {
+      if (!enabled) return;
+      const text = input.value.trim();
+      if (!text) return;
+      const ok = await config.onSend(text);
+      if (ok !== false) {
+        input.value = '';
+      }
+    }
+
+    fab.addEventListener('click', () => setOpen(!isOpen));
+    closeBtn.addEventListener('click', () => setOpen(false));
+    sendBtn.addEventListener('click', send);
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        send();
+      }
+    });
+
+    return {
+      setEnabled(value) {
+        enabled = Boolean(value);
+        root.style.display = enabled ? '' : 'none';
+        if (!enabled) setOpen(false);
+      },
+      setTitle(title) {
+        titleEl.textContent = title || config.title;
+      },
+      setEmptyMessage(message) {
+        emptyMessage = message || config.emptyMessage;
+        renderMessages();
+      },
+      setMessages(nextMessages, nextEmptyMessage) {
+        messages = Array.isArray(nextMessages) ? nextMessages : [];
+        if (typeof nextEmptyMessage === 'string') {
+          emptyMessage = nextEmptyMessage;
+        }
+        renderMessages();
+      },
+      appendMessage(message, countUnread = true) {
+        messages.push(message);
+        if (messages.length > 100) {
+          messages.splice(0, messages.length - 100);
+        }
+        renderMessages();
+        if (!isOpen && countUnread) {
+          unreadCount += 1;
+          syncUnreadBadge();
+        }
+      },
+      open() {
+        setOpen(true);
+      },
+      close() {
+        setOpen(false);
+      },
+      isOpen() {
+        return isOpen;
+      },
+      incrementUnread(count = 1) {
+        const next = Number(count);
+        if (!Number.isFinite(next) || next <= 0) return;
+        unreadCount += Math.floor(next);
+        syncUnreadBadge();
+      },
+      setUnreadCount(count = 0) {
+        const next = Number(count);
+        unreadCount = Number.isFinite(next) ? Math.max(0, Math.floor(next)) : 0;
+        syncUnreadBadge();
+      },
+      setPosition(position) {
+        applyPosition(position);
+      }
+    };
+  }
+
+  window.SoundcastFloatingChat = { create: createChatWidget };
+})();

--- a/src/public/room-publish.html
+++ b/src/public/room-publish.html
@@ -22,9 +22,18 @@
       background: white;
       border-radius: 20px;
       padding: 40px;
-      max-width: 600px;
+      max-width: 1200px;
       width: 100%;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+
+    .publisher-layout {
+      display: block;
+    }
+
+    .publisher-main,
+    .publisher-transcript {
+      min-width: 0;
     }
 
     .header {
@@ -357,25 +366,6 @@
       background: #f8fafc;
     }
 
-    .chat-log {
-      max-height: 150px;
-      overflow-y: auto;
-      border: 1px solid #e2e8f0;
-      background: white;
-      border-radius: 6px;
-      padding: 8px;
-      margin-bottom: 8px;
-      font-size: 12px;
-    }
-
-    .chat-msg {
-      margin-bottom: 6px;
-    }
-
-    .chat-msg strong {
-      color: #4a5568;
-    }
-
     .monitor-row {
       display: flex;
       gap: 8px;
@@ -388,6 +378,23 @@
       width: auto;
       padding: 8px 12px;
       font-size: 13px;
+    }
+
+    .chat-row {
+      margin-bottom: 6px;
+    }
+
+    @media (min-width: 1100px) {
+      .publisher-layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 360px;
+        gap: 20px;
+        align-items: start;
+      }
+
+      .publisher-transcript .transcript-toggle {
+        margin-top: 0;
+      }
     }
 
   </style>
@@ -405,76 +412,74 @@
       </div>
     </div>
 
-    <div id="status" class="status disconnected">
-      Connecting to room...
-    </div>
+    <div class="publisher-layout">
+      <div class="publisher-main">
+        <div id="status" class="status disconnected">
+          Connecting to room...
+        </div>
 
-    <div class="listener-count" id="listenerCount" style="display: none;">
-      <span class="listener-count-icon">&#128266;</span>
-      <span class="listener-count-value" id="listenerCountValue">0</span>
-      <span class="listener-count-label" id="listenerCountLabel">listeners</span>
-    </div>
+        <div class="listener-count" id="listenerCount" style="display: none;">
+          <span class="listener-count-icon">&#128266;</span>
+          <span class="listener-count-value" id="listenerCountValue">0</span>
+          <span class="listener-count-label" id="listenerCountLabel">listeners</span>
+        </div>
 
-    <div id="errorMessage" class="error"></div>
+        <div id="errorMessage" class="error"></div>
 
-    <div id="configInfo" class="info-box" style="display: none;">
-      <div class="info-label">SFU Configuration</div>
-      <div class="info-value" id="sfuUrl"></div>
-    </div>
+        <div id="configInfo" class="info-box" style="display: none;">
+          <div class="info-label">SFU Configuration</div>
+          <div class="info-value" id="sfuUrl"></div>
+        </div>
 
-    <div id="audioSourceContainer" style="display: none;">
-      <label class="info-label">Audio Source</label>
-      <select id="audioSource" class="audio-source-select">
-        <option value="">Select audio source</option>
-      </select>
-    </div>
+        <div id="audioSourceContainer" style="display: none;">
+          <label class="info-label">Audio Source</label>
+          <select id="audioSource" class="audio-source-select">
+            <option value="">Select audio source</option>
+          </select>
+        </div>
 
-    <div class="audio-meter" id="audioMeter" style="display: none;">
-      <div class="audio-meter-label">Audio Level</div>
-      <div class="audio-meter-bar" id="audioMeterBar"></div>
-    </div>
+        <div class="audio-meter" id="audioMeter" style="display: none;">
+          <div class="audio-meter-label">Audio Level</div>
+          <div class="audio-meter-bar" id="audioMeterBar"></div>
+        </div>
 
-    <button id="startBtn" class="btn btn-primary" onclick="startBroadcast()" disabled>
-      Start Broadcasting
-    </button>
-    <button id="stopBtn" class="btn btn-danger" onclick="stopBroadcast(true)" style="display: none;">
-      Stop Broadcasting
-    </button>
+        <button id="startBtn" class="btn btn-primary" onclick="startBroadcast()" disabled>
+          Start Broadcasting
+        </button>
+        <button id="stopBtn" class="btn btn-danger" onclick="stopBroadcast(true)" style="display: none;">
+          Stop Broadcasting
+        </button>
 
-    <div class="chat-box">
-      <div class="info-label">Monitor Another Channel</div>
-      <select id="monitorChannelSelect" class="audio-source-select">
-        <option value="">Select channel to monitor</option>
-      </select>
-      <div class="monitor-row">
-        <button id="startMonitorBtn" class="btn btn-primary" onclick="startMonitorChannel()">Start Monitor</button>
-        <button id="stopMonitorBtn" class="btn btn-danger" onclick="stopMonitorChannel()" style="display:none;">Stop Monitor</button>
+        <div class="chat-box">
+          <div class="info-label">Monitor Another Channel</div>
+          <select id="monitorChannelSelect" class="audio-source-select">
+            <option value="">Select channel to monitor</option>
+          </select>
+          <div class="monitor-row">
+            <button id="startMonitorBtn" class="btn btn-primary" onclick="startMonitorChannel()">Start Monitor</button>
+            <button id="stopMonitorBtn" class="btn btn-danger" onclick="stopMonitorChannel()" style="display:none;">Stop Monitor</button>
+          </div>
+          <audio id="monitorAudioPlayer" autoplay playsinline></audio>
+        </div>
       </div>
-      <audio id="monitorAudioPlayer" autoplay playsinline></audio>
-    </div>
 
-    <div class="chat-box">
-      <div class="info-label">Admin Chat</div>
-      <div id="publisherChatLog" class="chat-log">No messages yet.</div>
-      <div class="monitor-row">
-        <input id="publisherChatInput" class="audio-source-select" type="text" placeholder="Message admin..." style="margin:0;">
-        <button class="btn btn-primary" onclick="sendPublisherChat()">Send</button>
+      <div class="publisher-transcript">
+        <button id="toggleTranscriptBtn" class="transcript-toggle" onclick="toggleTranscriptPanel()">
+          Show Transcripts
+        </button>
+        <div id="transcriptPanel" class="transcript-panel hidden">
+          <div id="transcriptStatus" class="transcript-status">Transcripts hidden</div>
+          <div id="transcriptTabs" class="transcript-tabs"></div>
+          <textarea id="transcriptEditor" class="transcript-editor" placeholder="Live transcript will appear here"></textarea>
+        </div>
       </div>
-    </div>
-
-    <button id="toggleTranscriptBtn" class="transcript-toggle" onclick="toggleTranscriptPanel()">
-      Show Transcripts
-    </button>
-    <div id="transcriptPanel" class="transcript-panel hidden">
-      <div id="transcriptStatus" class="transcript-status">Transcripts hidden</div>
-      <div id="transcriptTabs" class="transcript-tabs"></div>
-      <textarea id="transcriptEditor" class="transcript-editor" placeholder="Live transcript will appear here"></textarea>
     </div>
   </div>
 
   <script src="/js/bundles/mediasoup-client.js"></script>
   <script src="/js/common.js"></script>
   <script src="/js/transcript-sync.js"></script>
+  <script src="/js/floating-chat-widget.js"></script>
   <script>
     // Extract room slug from URL path (/room/:slug/publish)
     const pathParts = window.location.pathname.split('/');
@@ -521,6 +526,7 @@
     let monitorConsumers = [];
     let monitorRtpCapabilities = null;
     let monitorChannel = null;
+    let publisherChatWidget = null;
 
     // Reconnection state
     let roomReconnectAttempts = 0;
@@ -938,41 +944,22 @@
     }
 
     function renderPublisherChat(messages) {
-      const logEl = document.getElementById('publisherChatLog');
-      if (!messages.length) {
-        logEl.textContent = 'No messages yet.';
-        return;
-      }
-      logEl.innerHTML = messages.map(msg => {
-        const senderLabel = msg.sender === 'admin' ? 'Admin' : 'You';
-        return `<div class="chat-msg"><strong>${senderLabel}</strong> <small>${formatChatTimestamp(msg.timestamp)}</small><br>${escapeHtml(msg.text)}</div>`;
-      }).join('');
-      logEl.scrollTop = logEl.scrollHeight;
+      if (!publisherChatWidget) return;
+      publisherChatWidget.setMessages(Array.isArray(messages) ? messages : [], 'No messages yet.');
     }
 
     function appendPublisherChat(message) {
-      const logEl = document.getElementById('publisherChatLog');
-      if (!message || !message.text) return;
-      if (logEl.textContent === 'No messages yet.') {
-        logEl.textContent = '';
-      }
-      const senderLabel = message.sender === 'admin' ? 'Admin' : 'You';
-      const row = document.createElement('div');
-      row.className = 'chat-msg';
-      row.innerHTML = `<strong>${senderLabel}</strong> <small>${formatChatTimestamp(message.timestamp)}</small><br>${escapeHtml(message.text)}`;
-      logEl.appendChild(row);
-      logEl.scrollTop = logEl.scrollHeight;
+      if (!publisherChatWidget || !message || !message.text) return;
+      publisherChatWidget.appendMessage(message);
     }
 
-    function sendPublisherChat() {
-      const inputEl = document.getElementById('publisherChatInput');
-      const text = inputEl.value.trim();
-      if (!text || !ws || ws.readyState !== WebSocket.OPEN) return;
+    function sendPublisherChat(text) {
+      if (!text || !ws || ws.readyState !== WebSocket.OPEN) return false;
       ws.send(JSON.stringify({
         type: 'publisher-chat-send',
         data: { text }
       }));
-      inputEl.value = '';
+      return true;
     }
 
     // Handle recording status updates
@@ -1502,10 +1489,15 @@
       stopMonitorChannel();
     });
 
-    document.getElementById('publisherChatInput').addEventListener('keydown', (event) => {
-      if (event.key === 'Enter') {
-        event.preventDefault();
-        sendPublisherChat();
+    publisherChatWidget = window.SoundcastFloatingChat.create({
+      buttonLabel: 'Admin Chat',
+      title: 'Admin Chat',
+      inputPlaceholder: 'Message admin...',
+      emptyMessage: 'No messages yet.',
+      onSend: sendPublisherChat,
+      renderMessage: (message) => {
+        const senderLabel = message.sender === 'admin' ? 'Admin' : 'You';
+        return `<div class="chat-row"><strong>${senderLabel}</strong> <small>${formatChatTimestamp(message.timestamp)}</small><br>${escapeHtml(message.text)}</div>`;
       }
     });
 

--- a/src/public/room-publish.html
+++ b/src/public/room-publish.html
@@ -349,6 +349,47 @@
       resize: vertical;
     }
 
+    .chat-box {
+      margin-top: 12px;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 10px;
+      background: #f8fafc;
+    }
+
+    .chat-log {
+      max-height: 150px;
+      overflow-y: auto;
+      border: 1px solid #e2e8f0;
+      background: white;
+      border-radius: 6px;
+      padding: 8px;
+      margin-bottom: 8px;
+      font-size: 12px;
+    }
+
+    .chat-msg {
+      margin-bottom: 6px;
+    }
+
+    .chat-msg strong {
+      color: #4a5568;
+    }
+
+    .monitor-row {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      margin-top: 6px;
+    }
+
+    .monitor-row button {
+      margin: 0;
+      width: auto;
+      padding: 8px 12px;
+      font-size: 13px;
+    }
+
   </style>
 </head>
 
@@ -399,6 +440,27 @@
     <button id="stopBtn" class="btn btn-danger" onclick="stopBroadcast(true)" style="display: none;">
       Stop Broadcasting
     </button>
+
+    <div class="chat-box">
+      <div class="info-label">Monitor Another Channel</div>
+      <select id="monitorChannelSelect" class="audio-source-select">
+        <option value="">Select channel to monitor</option>
+      </select>
+      <div class="monitor-row">
+        <button id="startMonitorBtn" class="btn btn-primary" onclick="startMonitorChannel()">Start Monitor</button>
+        <button id="stopMonitorBtn" class="btn btn-danger" onclick="stopMonitorChannel()" style="display:none;">Stop Monitor</button>
+      </div>
+      <audio id="monitorAudioPlayer" autoplay playsinline></audio>
+    </div>
+
+    <div class="chat-box">
+      <div class="info-label">Admin Chat</div>
+      <div id="publisherChatLog" class="chat-log">No messages yet.</div>
+      <div class="monitor-row">
+        <input id="publisherChatInput" class="audio-source-select" type="text" placeholder="Message admin..." style="margin:0;">
+        <button class="btn btn-primary" onclick="sendPublisherChat()">Send</button>
+      </div>
+    </div>
 
     <button id="toggleTranscriptBtn" class="transcript-toggle" onclick="toggleTranscriptPanel()">
       Show Transcripts
@@ -453,6 +515,12 @@
     let pubSyntheticOscillator = null;
     let transcriptChannels = [];
     let transcriptBinding = null;
+    let monitorWs = null;
+    let monitorDevice = null;
+    let monitorTransport = null;
+    let monitorConsumers = [];
+    let monitorRtpCapabilities = null;
+    let monitorChannel = null;
 
     // Reconnection state
     let roomReconnectAttempts = 0;
@@ -782,6 +850,11 @@
             setStatus('Error: ' + message.data.message, 'disconnected');
           } else if (message.type === 'recording-status') {
             handleRecordingStatus(message);
+          } else if (message.type === 'publisher-chat-message') {
+            appendPublisherChat(message.data);
+          } else if (message.type === 'publisher-chat-history') {
+            const messages = Array.isArray(message?.data?.messages) ? message.data.messages : [];
+            renderPublisherChat(messages);
           }
         } catch (error) {
           console.error('Error handling message:', error);
@@ -811,6 +884,7 @@
         transcriptChannels = [config.channelName];
       }
       renderTranscriptTabs(transcriptChannels[0] || null);
+      populateMonitorChannels(transcriptChannels);
 
       // Display channel name
       if (config.channelName) {
@@ -841,6 +915,64 @@
 
       // Connect to SFU
       connectToSfu();
+      ws.send(JSON.stringify({ type: 'publisher-chat-history-request' }));
+    }
+
+    function populateMonitorChannels(channels) {
+      const selectEl = document.getElementById('monitorChannelSelect');
+      selectEl.innerHTML = '<option value="">Select channel to monitor</option>';
+      channels.forEach((channelName) => {
+        const option = document.createElement('option');
+        option.value = channelName;
+        option.textContent = channelName;
+        selectEl.appendChild(option);
+      });
+    }
+
+    function formatChatTimestamp(ts) {
+      try {
+        return new Date(ts).toLocaleTimeString();
+      } catch {
+        return '';
+      }
+    }
+
+    function renderPublisherChat(messages) {
+      const logEl = document.getElementById('publisherChatLog');
+      if (!messages.length) {
+        logEl.textContent = 'No messages yet.';
+        return;
+      }
+      logEl.innerHTML = messages.map(msg => {
+        const senderLabel = msg.sender === 'admin' ? 'Admin' : 'You';
+        return `<div class="chat-msg"><strong>${senderLabel}</strong> <small>${formatChatTimestamp(msg.timestamp)}</small><br>${escapeHtml(msg.text)}</div>`;
+      }).join('');
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function appendPublisherChat(message) {
+      const logEl = document.getElementById('publisherChatLog');
+      if (!message || !message.text) return;
+      if (logEl.textContent === 'No messages yet.') {
+        logEl.textContent = '';
+      }
+      const senderLabel = message.sender === 'admin' ? 'Admin' : 'You';
+      const row = document.createElement('div');
+      row.className = 'chat-msg';
+      row.innerHTML = `<strong>${senderLabel}</strong> <small>${formatChatTimestamp(message.timestamp)}</small><br>${escapeHtml(message.text)}`;
+      logEl.appendChild(row);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function sendPublisherChat() {
+      const inputEl = document.getElementById('publisherChatInput');
+      const text = inputEl.value.trim();
+      if (!text || !ws || ws.readyState !== WebSocket.OPEN) return;
+      ws.send(JSON.stringify({
+        type: 'publisher-chat-send',
+        data: { text }
+      }));
+      inputEl.value = '';
     }
 
     // Handle recording status updates
@@ -960,6 +1092,115 @@
         default:
           console.log('Unknown SFU action:', action);
       }
+    }
+
+    function connectMonitorWs() {
+      if (monitorWs && monitorWs.readyState === WebSocket.OPEN) return;
+      const sfuUrl = getSfuWsUrl();
+      monitorWs = new WebSocket(sfuUrl);
+      monitorWs.onopen = () => {
+        monitorWs.send(JSON.stringify({ action: 'get-rtpCapabilities' }));
+      };
+      monitorWs.onmessage = async (event) => {
+        let data;
+        try {
+          data = JSON.parse(event.data);
+        } catch {
+          return;
+        }
+        const { action, data: payload } = data;
+        if (action === 'rtpCapabilities') {
+          monitorRtpCapabilities = payload;
+          await joinMonitorChannel();
+        } else if (action === 'listener-transport-created') {
+          await handleMonitorTransport(payload);
+        } else if (action === 'consumer-created') {
+          await handleMonitorConsumer(payload);
+        }
+      };
+    }
+
+    async function startMonitorChannel() {
+      const selected = document.getElementById('monitorChannelSelect').value;
+      if (!selected) {
+        showError('Select a monitor channel first');
+        return;
+      }
+      if (monitorChannel === selected && monitorTransport) return;
+      stopMonitorChannel();
+      monitorChannel = selected;
+      connectMonitorWs();
+      document.getElementById('startMonitorBtn').style.display = 'none';
+      document.getElementById('stopMonitorBtn').style.display = 'inline-block';
+    }
+
+    async function joinMonitorChannel() {
+      if (!monitorChannel || !monitorWs || monitorWs.readyState !== WebSocket.OPEN) return;
+      monitorDevice = new mediasoupClient.Device();
+      await monitorDevice.load({ routerRtpCapabilities: monitorRtpCapabilities });
+      monitorWs.send(JSON.stringify({
+        action: 'create-listener-transport',
+        data: {
+          channelId: `${roomSlug}:${monitorChannel}`,
+          displayName: 'Publisher monitor'
+        }
+      }));
+    }
+
+    async function handleMonitorTransport(transportParams) {
+      const iceServers = getIceServersFromConfig(roomConfig);
+      transportParams.iceServers = iceServers;
+      monitorTransport = monitorDevice.createRecvTransport(transportParams);
+      monitorTransport.on('connect', ({ dtlsParameters }, callback, errback) => {
+        try {
+          monitorWs.send(JSON.stringify({
+            action: 'connect-listener-transport',
+            data: { dtlsParameters }
+          }));
+          callback();
+        } catch (error) {
+          errback(error);
+        }
+      });
+      monitorWs.send(JSON.stringify({
+        action: 'consume-audio',
+        data: { rtpCapabilities: monitorDevice.rtpCapabilities }
+      }));
+    }
+
+    async function handleMonitorConsumer(payload) {
+      const entries = Array.isArray(payload) ? payload : [payload];
+      const stream = new MediaStream();
+      for (const item of entries) {
+        const consumer = await monitorTransport.consume({
+          id: item.id,
+          producerId: item.producerId,
+          kind: item.kind,
+          rtpParameters: item.rtpParameters
+        });
+        monitorConsumers.push(consumer);
+        stream.addTrack(consumer.track);
+      }
+      document.getElementById('monitorAudioPlayer').srcObject = stream;
+    }
+
+    function stopMonitorChannel() {
+      if (monitorWs && monitorWs.readyState === WebSocket.OPEN) {
+        monitorWs.send(JSON.stringify({ action: 'leave-channel', data: {} }));
+      }
+      monitorConsumers.forEach((consumer) => {
+        try { consumer.close(); } catch { }
+      });
+      monitorConsumers = [];
+      if (monitorTransport) {
+        try { monitorTransport.close(); } catch { }
+      }
+      monitorTransport = null;
+      monitorDevice = null;
+      monitorChannel = null;
+      document.getElementById('monitorAudioPlayer').srcObject = null;
+      document.getElementById('startMonitorBtn').style.display = 'inline-block';
+      document.getElementById('stopMonitorBtn').style.display = 'none';
     }
 
     // Handle transport created
@@ -1258,6 +1499,14 @@
     window.addEventListener('beforeunload', () => {
       destroyTranscriptBinding();
       stopBroadcast(true); // Intentional stop (user leaving page)
+      stopMonitorChannel();
+    });
+
+    document.getElementById('publisherChatInput').addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        sendPublisherChat();
+      }
     });
 
     // Initialize

--- a/src/public/tenant-admin.html
+++ b/src/public/tenant-admin.html
@@ -619,33 +619,8 @@
       text-align: right;
     }
 
-    .chat-panel {
-      margin-top: 16px;
-      border: 1px solid #cbd5e0;
-      border-radius: 8px;
-      padding: 12px;
-      background: #f8fafc;
-      display: none;
-    }
-
-    .chat-log {
-      max-height: 220px;
-      overflow-y: auto;
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 6px;
-      padding: 10px;
-      margin: 8px 0;
-      font-size: 13px;
-    }
-
     .chat-row {
       margin-bottom: 8px;
-    }
-
-    .chat-composer {
-      display: flex;
-      gap: 8px;
     }
   </style>
 </head>
@@ -682,14 +657,6 @@
       </div>
       <div id="roomsList">
         <div class="loading">Loading rooms...</div>
-      </div>
-      <div id="adminChatPanel" class="chat-panel">
-        <div id="adminChatTitle" style="font-weight: bold;">Publisher Chat</div>
-        <div id="adminChatLog" class="chat-log">Select a publisher to chat.</div>
-        <div class="chat-composer">
-          <input id="adminChatInput" type="text" class="form-input" placeholder="Send message to publisher...">
-          <button class="btn btn-primary" onclick="sendAdminChat()">Send</button>
-        </div>
       </div>
     </div>
 
@@ -790,6 +757,7 @@
   </div>
 
   <script src="/js/transcript-sync.js"></script>
+  <script src="/js/floating-chat-widget.js"></script>
   <script>
     const API_BASE = window.location.origin + '/api';
     let currentApiKey = '';
@@ -802,7 +770,9 @@
     let transcriptSessions = {}; // roomSlug -> session[]
     let transcriptSessionState = {}; // roomSlug -> { limit, offset, total, selectedSessionId }
     let adminChatMessages = {}; // key: roomSlug:publisherId -> messages[]
-    let activeChat = null; // { roomSlug, publisherId, publisherName }
+    let adminChatWidgets = {}; // key: roomSlug:publisherId -> floating chat widget
+    let adminChatWindowOrder = []; // preserve window stacking order
+    let adminChatEnabled = false;
 
     // ========== Reactive State Management ==========
     // Lightweight state store with change notifications using Proxy
@@ -1002,7 +972,10 @@
             if (!roomSlug || !publisherId) return;
             const key = getAdminChatKey(roomSlug, publisherId);
             adminChatMessages[key] = Array.isArray(msg?.data?.messages) ? msg.data.messages : [];
-            renderActiveAdminChat();
+            const widget = adminChatWidgets[key];
+            if (widget) {
+              widget.setMessages(adminChatMessages[key], 'No messages yet.');
+            }
           } else if (msg.type === 'error') {
             console.error('Admin WebSocket error:', msg.data.message);
           }
@@ -1109,6 +1082,73 @@
       return `${roomSlug}:${publisherId}`;
     }
 
+    function getAdminChatMetaFromKey(key) {
+      const idx = key.lastIndexOf(':');
+      if (idx < 0) return null;
+      return {
+        roomSlug: key.slice(0, idx),
+        publisherId: Number(key.slice(idx + 1))
+      };
+    }
+
+    function getAdminChatWindowPosition(key) {
+      const index = adminChatWindowOrder.indexOf(key);
+      const safeIndex = index >= 0 ? index : adminChatWindowOrder.length;
+      const panelWidth = 360;
+      const panelGap = 20;
+      const rightBase = 20;
+      const panelStepX = panelWidth + panelGap;
+      const panelStepY = 360;
+      const fabStepY = 56;
+      const viewportWidth = window.innerWidth || 1440;
+      const usableWidth = Math.max(320, viewportWidth - (rightBase * 2));
+      const columns = Math.max(1, Math.floor((usableWidth + panelGap) / panelStepX));
+      const col = safeIndex % columns;
+      const row = Math.floor(safeIndex / columns);
+      return {
+        right: rightBase + (col * panelStepX),
+        panelBottom: 74 + (row * panelStepY),
+        fabBottom: 20 + (row * fabStepY)
+      };
+    }
+
+    function relayoutAdminChatWindows() {
+      for (const key of adminChatWindowOrder) {
+        const widget = adminChatWidgets[key];
+        if (!widget) continue;
+        widget.setPosition(getAdminChatWindowPosition(key));
+      }
+    }
+
+    function ensureAdminChatWidget(roomSlug, publisherId, publisherName) {
+      const key = getAdminChatKey(roomSlug, publisherId);
+      if (!adminChatWindowOrder.includes(key)) {
+        adminChatWindowOrder.push(key);
+      }
+      if (adminChatWidgets[key]) {
+        return adminChatWidgets[key];
+      }
+
+      const widget = window.SoundcastFloatingChat.create({
+        buttonLabel: publisherName || `Chat ${publisherId}`,
+        title: `Chat with ${publisherName || ('Publisher ' + publisherId)} (${roomSlug})`,
+        inputPlaceholder: 'Send message to publisher...',
+        emptyMessage: 'No messages yet.',
+        position: getAdminChatWindowPosition(key),
+        onSend: (text) => sendAdminChatForKey(key, text),
+        renderMessage: (msg) => {
+          const sender = msg.sender === 'admin' ? 'You' : (msg.publisherName || 'Publisher');
+          return `<div class="chat-row"><strong>${escapeHtml(sender)}</strong> <small>${formatChatTime(msg.timestamp)}</small><br>${escapeHtml(msg.text)}</div>`;
+        }
+      });
+
+      widget.setEnabled(adminChatEnabled);
+      widget.setMessages(adminChatMessages[key] || [], 'No messages yet.');
+      adminChatWidgets[key] = widget;
+      relayoutAdminChatWindows();
+      return widget;
+    }
+
     function formatChatTime(timestamp) {
       try {
         return new Date(timestamp).toLocaleTimeString();
@@ -1127,14 +1167,20 @@
       if (adminChatMessages[key].length > 100) {
         adminChatMessages[key].splice(0, adminChatMessages[key].length - 100);
       }
-      renderActiveAdminChat();
+      const widget = ensureAdminChatWidget(message.roomSlug, message.publisherId, message.publisherName);
+      const wasOpen = widget.isOpen();
+      widget.setMessages(adminChatMessages[key], 'No messages yet.');
+      if (!wasOpen) {
+        widget.incrementUnread(1);
+      }
     }
 
     function openAdminChat(roomSlug, publisherId, publisherName) {
-      activeChat = { roomSlug, publisherId, publisherName };
-      document.getElementById('adminChatPanel').style.display = 'block';
-      document.getElementById('adminChatTitle').textContent = `Chat with ${publisherName} (${roomSlug})`;
-      renderActiveAdminChat();
+      const key = getAdminChatKey(roomSlug, publisherId);
+      const widget = ensureAdminChatWidget(roomSlug, publisherId, publisherName);
+      widget.setTitle(`Chat with ${publisherName} (${roomSlug})`);
+      widget.setMessages(adminChatMessages[key] || [], 'No messages yet.');
+      widget.open();
       if (adminWs && adminWs.readyState === WebSocket.OPEN) {
         adminWs.send(JSON.stringify({
           type: 'admin-chat-history-request',
@@ -1143,41 +1189,32 @@
       }
     }
 
-    function renderActiveAdminChat() {
-      const logEl = document.getElementById('adminChatLog');
-      if (!activeChat) return;
-      const key = getAdminChatKey(activeChat.roomSlug, activeChat.publisherId);
-      const messages = adminChatMessages[key] || [];
-      if (messages.length === 0) {
-        logEl.textContent = 'No messages yet.';
-        return;
+    async function sendAdminChatForKey(key, text) {
+      const chatMeta = getAdminChatMetaFromKey(key);
+      if (!chatMeta) return false;
+      if (!adminWs || adminWs.readyState !== WebSocket.OPEN) {
+        showError('Chat connection is not ready yet');
+        return false;
       }
-      logEl.innerHTML = messages.map((msg) => {
-        const sender = msg.sender === 'admin' ? 'You' : (msg.publisherName || 'Publisher');
-        return `<div class="chat-row"><strong>${escapeHtml(sender)}</strong> <small>${formatChatTime(msg.timestamp)}</small><br>${escapeHtml(msg.text)}</div>`;
-      }).join('');
-      logEl.scrollTop = logEl.scrollHeight;
-    }
-
-    function sendAdminChat() {
-      if (!activeChat || !adminWs || adminWs.readyState !== WebSocket.OPEN) return;
-      const inputEl = document.getElementById('adminChatInput');
-      const text = inputEl.value.trim();
-      if (!text) return;
+      if (!text) return false;
       adminWs.send(JSON.stringify({
         type: 'admin-chat-send',
         data: {
-          roomSlug: activeChat.roomSlug,
-          publisherId: activeChat.publisherId,
+          roomSlug: chatMeta.roomSlug,
+          publisherId: chatMeta.publisherId,
           text
         }
       }));
-      inputEl.value = '';
+      return true;
     }
 
     function showAuthenticatedView() {
       document.getElementById('apiKeySection').style.display = 'none';
       document.getElementById('roomsSection').style.display = 'block';
+      adminChatEnabled = true;
+      for (const widget of Object.values(adminChatWidgets)) {
+        widget.setEnabled(true);
+      }
 
       // Connect WebSocket for real-time stats
       connectAdminWebSocket();
@@ -2402,16 +2439,10 @@ ${baseUrl}/room/${slug}/publish?token=${p.join_token}`
 
     // Initialize on page load
     document.addEventListener('DOMContentLoaded', () => {
+      window.addEventListener('resize', () => {
+        relayoutAdminChatWindows();
+      });
       checkSingleTenantMode();
-      const chatInput = document.getElementById('adminChatInput');
-      if (chatInput) {
-        chatInput.addEventListener('keydown', (event) => {
-          if (event.key === 'Enter') {
-            event.preventDefault();
-            sendAdminChat();
-          }
-        });
-      }
     });
   </script>
 </body>

--- a/src/public/tenant-admin.html
+++ b/src/public/tenant-admin.html
@@ -618,6 +618,35 @@
       min-width: 120px;
       text-align: right;
     }
+
+    .chat-panel {
+      margin-top: 16px;
+      border: 1px solid #cbd5e0;
+      border-radius: 8px;
+      padding: 12px;
+      background: #f8fafc;
+      display: none;
+    }
+
+    .chat-log {
+      max-height: 220px;
+      overflow-y: auto;
+      background: white;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      padding: 10px;
+      margin: 8px 0;
+      font-size: 13px;
+    }
+
+    .chat-row {
+      margin-bottom: 8px;
+    }
+
+    .chat-composer {
+      display: flex;
+      gap: 8px;
+    }
   </style>
 </head>
 
@@ -653,6 +682,14 @@
       </div>
       <div id="roomsList">
         <div class="loading">Loading rooms...</div>
+      </div>
+      <div id="adminChatPanel" class="chat-panel">
+        <div id="adminChatTitle" style="font-weight: bold;">Publisher Chat</div>
+        <div id="adminChatLog" class="chat-log">Select a publisher to chat.</div>
+        <div class="chat-composer">
+          <input id="adminChatInput" type="text" class="form-input" placeholder="Send message to publisher...">
+          <button class="btn btn-primary" onclick="sendAdminChat()">Send</button>
+        </div>
       </div>
     </div>
 
@@ -764,6 +801,8 @@
     let transcriptChannels = {}; // roomSlug -> channelName[]
     let transcriptSessions = {}; // roomSlug -> session[]
     let transcriptSessionState = {}; // roomSlug -> { limit, offset, total, selectedSessionId }
+    let adminChatMessages = {}; // key: roomSlug:publisherId -> messages[]
+    let activeChat = null; // { roomSlug, publisherId, publisherName }
 
     // ========== Reactive State Management ==========
     // Lightweight state store with change notifications using Proxy
@@ -955,6 +994,15 @@
             updateRecordingUI(msg.roomSlug);
             handleTranscriptRecordingStatusUpdate(msg.roomSlug, msg)
               .catch((error) => console.warn('Failed to refresh transcript session on recording update:', error));
+          } else if (msg.type === 'publisher-chat-message') {
+            addAdminChatMessage(msg.data);
+          } else if (msg.type === 'publisher-chat-history') {
+            const roomSlug = msg?.data?.roomSlug;
+            const publisherId = msg?.data?.publisherId;
+            if (!roomSlug || !publisherId) return;
+            const key = getAdminChatKey(roomSlug, publisherId);
+            adminChatMessages[key] = Array.isArray(msg?.data?.messages) ? msg.data.messages : [];
+            renderActiveAdminChat();
           } else if (msg.type === 'error') {
             console.error('Admin WebSocket error:', msg.data.message);
           }
@@ -1055,6 +1103,76 @@
       el.textContent = message;
       el.style.display = 'block';
       setTimeout(() => el.style.display = 'none', 5000);
+    }
+
+    function getAdminChatKey(roomSlug, publisherId) {
+      return `${roomSlug}:${publisherId}`;
+    }
+
+    function formatChatTime(timestamp) {
+      try {
+        return new Date(timestamp).toLocaleTimeString();
+      } catch {
+        return '';
+      }
+    }
+
+    function addAdminChatMessage(message) {
+      if (!message?.roomSlug || !message?.publisherId) return;
+      const key = getAdminChatKey(message.roomSlug, message.publisherId);
+      if (!adminChatMessages[key]) {
+        adminChatMessages[key] = [];
+      }
+      adminChatMessages[key].push(message);
+      if (adminChatMessages[key].length > 100) {
+        adminChatMessages[key].splice(0, adminChatMessages[key].length - 100);
+      }
+      renderActiveAdminChat();
+    }
+
+    function openAdminChat(roomSlug, publisherId, publisherName) {
+      activeChat = { roomSlug, publisherId, publisherName };
+      document.getElementById('adminChatPanel').style.display = 'block';
+      document.getElementById('adminChatTitle').textContent = `Chat with ${publisherName} (${roomSlug})`;
+      renderActiveAdminChat();
+      if (adminWs && adminWs.readyState === WebSocket.OPEN) {
+        adminWs.send(JSON.stringify({
+          type: 'admin-chat-history-request',
+          data: { roomSlug, publisherId }
+        }));
+      }
+    }
+
+    function renderActiveAdminChat() {
+      const logEl = document.getElementById('adminChatLog');
+      if (!activeChat) return;
+      const key = getAdminChatKey(activeChat.roomSlug, activeChat.publisherId);
+      const messages = adminChatMessages[key] || [];
+      if (messages.length === 0) {
+        logEl.textContent = 'No messages yet.';
+        return;
+      }
+      logEl.innerHTML = messages.map((msg) => {
+        const sender = msg.sender === 'admin' ? 'You' : (msg.publisherName || 'Publisher');
+        return `<div class="chat-row"><strong>${escapeHtml(sender)}</strong> <small>${formatChatTime(msg.timestamp)}</small><br>${escapeHtml(msg.text)}</div>`;
+      }).join('');
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function sendAdminChat() {
+      if (!activeChat || !adminWs || adminWs.readyState !== WebSocket.OPEN) return;
+      const inputEl = document.getElementById('adminChatInput');
+      const text = inputEl.value.trim();
+      if (!text) return;
+      adminWs.send(JSON.stringify({
+        type: 'admin-chat-send',
+        data: {
+          roomSlug: activeChat.roomSlug,
+          publisherId: activeChat.publisherId,
+          text
+        }
+      }));
+      inputEl.value = '';
     }
 
     function showAuthenticatedView() {
@@ -1299,6 +1417,7 @@
                   </td>
                   <td style="text-align: right; padding: 8px;">
                     <button class="copy-btn" onclick="copyToClipboard('${escapeAttr(baseUrl + '/room/' + slug + '/publish?token=' + pub.join_token)}')">Copy URL</button>
+                    <button class="btn btn-secondary btn-small" style="margin-left: 5px; padding: 4px 8px;" onclick="openAdminChat('${slug}', ${pub.id}, '${escapeAttr(pub.name)}')">Chat</button>
                     <button class="btn btn-primary btn-small" style="margin-left: 5px; padding: 4px 8px;" onclick="showEditPublisherModal('${slug}', ${pub.id}, '${escapeAttr(pub.name)}', '${escapeAttr(pub.channel_name)}')">Edit</button>
                     <button class="btn btn-danger btn-small" style="margin-left: 5px; padding: 4px 8px;" onclick="deletePublisher('${slug}', ${pub.id})">Delete</button>
                   </td>
@@ -2282,7 +2401,18 @@ ${baseUrl}/room/${slug}/publish?token=${p.join_token}`
     });
 
     // Initialize on page load
-    document.addEventListener('DOMContentLoaded', checkSingleTenantMode);
+    document.addEventListener('DOMContentLoaded', () => {
+      checkSingleTenantMode();
+      const chatInput = document.getElementById('adminChatInput');
+      if (chatInput) {
+        chatInput.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            sendAdminChat();
+          }
+        });
+      }
+    });
   </script>
 </body>
 

--- a/src/server.js
+++ b/src/server.js
@@ -201,6 +201,37 @@ const clients = new Map();
 
 // Tenant admin WebSocket connections: tenantId -> Set<socket>
 const tenantAdminClients = new Map();
+// Active room publisher sockets keyed by publisher DB id
+const roomPublisherClients = new Map();
+// In-memory chat history by publisher id
+const publisherChatHistory = new Map();
+
+function pushPublisherChatMessage(publisherId, message) {
+  if (!publisherChatHistory.has(publisherId)) {
+    publisherChatHistory.set(publisherId, []);
+  }
+  const history = publisherChatHistory.get(publisherId);
+  history.push(message);
+  if (history.length > 100) {
+    history.splice(0, history.length - 100);
+  }
+}
+
+function getPublisherChatHistory(publisherId) {
+  return publisherChatHistory.get(publisherId) || [];
+}
+
+function broadcastTenantAdminMessage(tenantId, payload) {
+  const adminSockets = tenantAdminClients.get(tenantId);
+  if (!adminSockets || adminSockets.size === 0) return;
+  for (const socket of adminSockets) {
+    try {
+      socket.send(JSON.stringify(payload));
+    } catch (e) {
+      fastify.log.error(`Failed sending tenant admin message: ${e.message}`);
+    }
+  }
+}
 
 // Broadcast updated channel list to all clients
 function broadcastChannelList() {
@@ -1612,6 +1643,15 @@ async function registerRoomWsRoutes(fastify) {
       return;
     }
 
+    roomPublisherClients.set(publisher.id, {
+      socket: connection,
+      publisherId: publisher.id,
+      publisherName: publisher.name,
+      roomSlug: slug,
+      roomId: room.id,
+      tenantId: room.tenant_id
+    });
+
     const iceServers = DEFAULT_ICE_SERVERS;
     const transcriptionStatus = transcriptionRuntime ? transcriptionRuntime.getRoomTranscriptionStatus(room.id) : null;
 
@@ -1645,6 +1685,34 @@ async function registerRoomWsRoutes(fastify) {
           // Client requests config after handlers are ready (fixes iOS Safari timing issue)
           connection.send(JSON.stringify(config));
           fastify.log.info(`Config sent to publisher ${clientId} (${publisher.name}) for room ${slug}, channel: ${publisher.channel_name}`);
+        } else if (payload.type === 'publisher-chat-history-request') {
+          connection.send(JSON.stringify({
+            type: 'publisher-chat-history',
+            data: {
+              messages: getPublisherChatHistory(publisher.id)
+            }
+          }));
+        } else if (payload.type === 'publisher-chat-send') {
+          const text = typeof payload?.data?.text === 'string' ? payload.data.text.trim() : '';
+          if (!text) return;
+          const chatMessage = {
+            id: uuidv4(),
+            roomSlug: slug,
+            publisherId: publisher.id,
+            publisherName: publisher.name,
+            sender: 'publisher',
+            text: text.slice(0, 1000),
+            timestamp: new Date().toISOString()
+          };
+          pushPublisherChatMessage(publisher.id, chatMessage);
+          connection.send(JSON.stringify({
+            type: 'publisher-chat-message',
+            data: chatMessage
+          }));
+          broadcastTenantAdminMessage(room.tenant_id, {
+            type: 'publisher-chat-message',
+            data: chatMessage
+          });
         } else if (payload.type === 'webrtc_signal') {
           // In a full implementation, this would relay to the SFU
           // For now, we just log it
@@ -1657,6 +1725,7 @@ async function registerRoomWsRoutes(fastify) {
 
     connection.on('close', () => {
       fastify.log.info(`Publisher ${clientId} (${publisher.name}) disconnected from room ${slug}`);
+      roomPublisherClients.delete(publisher.id);
     });
   });
 }
@@ -1727,6 +1796,68 @@ async function registerAdminWsRoutes(fastify) {
           connection.send(JSON.stringify({
             type: 'recording-stats',
             stats: recordingStats
+          }));
+        } else if (payload.type === 'admin-chat-send') {
+          const publisherId = Number(payload?.data?.publisherId);
+          const roomSlug = typeof payload?.data?.roomSlug === 'string' ? payload.data.roomSlug : '';
+          const text = typeof payload?.data?.text === 'string' ? payload.data.text.trim() : '';
+          if (!publisherId || !roomSlug || !text) return;
+
+          const room = getRoomBySlug(roomSlug);
+          if (!room || room.tenant_id !== tenant.id) return;
+
+          const db = getDatabase();
+          const pubStmt = db.prepare('SELECT id, name, room_id FROM publishers WHERE id = ?');
+          const publisher = pubStmt.get(publisherId);
+          if (!publisher || publisher.room_id !== room.id) return;
+
+          const chatMessage = {
+            id: uuidv4(),
+            roomSlug,
+            publisherId: publisher.id,
+            publisherName: publisher.name,
+            sender: 'admin',
+            text: text.slice(0, 1000),
+            timestamp: new Date().toISOString()
+          };
+          pushPublisherChatMessage(publisher.id, chatMessage);
+
+          const publisherClient = roomPublisherClients.get(publisher.id);
+          if (publisherClient) {
+            try {
+              publisherClient.socket.send(JSON.stringify({
+                type: 'publisher-chat-message',
+                data: chatMessage
+              }));
+            } catch (e) {
+              fastify.log.error(`Failed sending admin chat message to publisher: ${e.message}`);
+            }
+          }
+
+          broadcastTenantAdminMessage(tenant.id, {
+            type: 'publisher-chat-message',
+            data: chatMessage
+          });
+        } else if (payload.type === 'admin-chat-history-request') {
+          const publisherId = Number(payload?.data?.publisherId);
+          const roomSlug = typeof payload?.data?.roomSlug === 'string' ? payload.data.roomSlug : '';
+          if (!publisherId || !roomSlug) return;
+
+          const room = getRoomBySlug(roomSlug);
+          if (!room || room.tenant_id !== tenant.id) return;
+
+          const db = getDatabase();
+          const pubStmt = db.prepare('SELECT id, room_id FROM publishers WHERE id = ?');
+          const publisher = pubStmt.get(publisherId);
+          if (!publisher || publisher.room_id !== room.id) return;
+
+          connection.send(JSON.stringify({
+            type: 'publisher-chat-history',
+            data: {
+              roomSlug,
+              publisherId,
+              messages: getPublisherChatHistory(publisherId)
+            }
           }));
         }
       } catch (e) {


### PR DESCRIPTION
### Motivation
- Allow tenant admins and room publishers to exchange messages for live coordination without leaving the app. 
- Let publishers monitor (listen to) any room channel in-place instead of opening a separate listener page. 
- Keep chat lightweight and transient with an in-memory store to avoid introducing DB schema changes for now.

### Description
- Server: added `roomPublisherClients` and `publisherChatHistory` maps and helpers (`pushPublisherChatMessage`, `getPublisherChatHistory`, `broadcastTenantAdminMessage`) and wired publisher-originated chat (`publisher-chat-send`, `publisher-chat-history-request`) in the room publisher WS handler (`/ws/room/:slug/publish`).
- Server: extended admin WebSocket (`/ws/admin`) to accept `admin-chat-send` and `admin-chat-history-request`, validate tenant/room/publisher relationships, persist chat messages in memory (capped at 100 messages per publisher), deliver messages to a connected publisher socket when available, and broadcast chat events to all tenant admin clients.
- Publisher UI (`src/public/room-publish.html`): added an **Admin Chat** panel with history loading, send/receive handling over the existing room WS connection, Enter-to-send behavior, and a **Monitor Another Channel** UI that creates a separate SFU recv transport (via a dedicated SFU websocket/recv flow) so a publisher can listen to another channel in-page without affecting the broadcast transport.
- Tenant admin UI (`src/public/tenant-admin.html`): added a per-publisher `Chat` action in the publishers table, an admin chat panel, message rendering and history loading, and Enter-to-send behavior wired to the admin WebSocket.
- Notes: chat history is intentionally in-memory and bounded (100 messages per publisher); message payloads include `id`, `roomSlug`, `publisherId`, `publisherName`, `sender`, `text`, and `timestamp`.

### Testing
- Performed a static check with `node --check src/server.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e442ee8e708322b15c7333bff00ebd)