### PR TITLE
Add RNNoise client-side noise suppression toggle and serve RNNoise assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fastify/static": "^8.1.1",
         "@fastify/websocket": "^11.0.2",
+        "@sapphi-red/web-noise-suppressor": "^0.3.5",
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "12.5.0",
         "dotenv": "^16.5.0",
@@ -257,6 +258,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@sapphi-red/web-noise-suppressor": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@sapphi-red/web-noise-suppressor/-/web-noise-suppressor-0.3.5.tgz",
+      "integrity": "sha512-jh3+V9yM+zxLriQexoGm0GatoPaJWjs6ypFIbFYwQp+AoUb55eUXrjKtKQyuC5zShzzeAQUl0M5JzqB7SSrsRA==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fastify/static": "^8.1.1",
     "@fastify/websocket": "^11.0.2",
+    "@sapphi-red/web-noise-suppressor": "^0.3.5",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "12.5.0",
     "dotenv": "^16.5.0",

--- a/src/public/room-publish.html
+++ b/src/public/room-publish.html
@@ -252,6 +252,22 @@
       border-color: #667eea;
     }
 
+    .audio-option-row {
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      font-size: 14px;
+      color: #2d3748;
+    }
+
+    .audio-option-help {
+      font-size: 12px;
+      color: #718096;
+      margin-bottom: 12px;
+    }
+
     /* Recording Indicator */
     .recording-indicator {
       display: none;
@@ -436,6 +452,13 @@
           <select id="audioSource" class="audio-source-select">
             <option value="">Select audio source</option>
           </select>
+          <label class="audio-option-row">
+            <span>RNNoise suppression (beta)</span>
+            <input type="checkbox" id="rnnoiseToggle">
+          </label>
+          <div class="audio-option-help" id="rnnoiseStatus">
+            Uses browser noise suppression by default. Enable RNNoise for stronger suppression.
+          </div>
         </div>
 
         <div class="audio-meter" id="audioMeter" style="display: none;">
@@ -511,11 +534,18 @@
     let pubTransport = null;
     let pubProducer = null;
     let pubAudioStream = null;
+    let pubRawAudioStream = null;
     let roomConfig = null;
     let pubAudioContext = null;
     let pubAudioMeter = null;
     let pubAudioSource = null;
     let pubMeterUpdateInterval = null;
+    let pubDenoiseSource = null;
+    let pubDenoiseDestination = null;
+    let pubRnnoiseNode = null;
+    let pubRnnoiseWorkletLoaded = false;
+    let rnnoiseModulePromise = null;
+    const rnnoiseAssetBase = '/vendor/web-noise-suppressor';
     let pubSyntheticAudioContext = null;
     let pubSyntheticOscillator = null;
     let transcriptChannels = [];
@@ -552,6 +582,26 @@
       statusEl.className = `status ${className}`;
     }
 
+    function isRnnoiseEnabled() {
+      return document.getElementById('rnnoiseToggle')?.checked === true;
+    }
+
+    function getMicAudioConstraints(audioSourceId) {
+      return {
+        ...(audioSourceId ? { deviceId: { exact: audioSourceId } } : {}),
+        echoCancellation: true,
+        noiseSuppression: !isRnnoiseEnabled(),
+        autoGainControl: true
+      };
+    }
+
+    function updateRnnoiseStatus(message) {
+      const statusEl = document.getElementById('rnnoiseStatus');
+      if (statusEl) {
+        statusEl.textContent = message;
+      }
+    }
+
     function showError(message) {
       const el = document.getElementById('errorMessage');
       el.textContent = message;
@@ -563,6 +613,87 @@
       const div = document.createElement('div');
       div.textContent = value || '';
       return div.innerHTML;
+    }
+
+    async function loadRnnoiseModule() {
+      if (rnnoiseModulePromise) {
+        return rnnoiseModulePromise;
+      }
+      rnnoiseModulePromise = import(`${rnnoiseAssetBase}/index.js`);
+      return rnnoiseModulePromise;
+    }
+
+    function resetDenoiseGraph() {
+      if (pubDenoiseSource) {
+        try {
+          pubDenoiseSource.disconnect();
+        } catch (error) {
+          console.warn('Failed to disconnect RNNoise source:', error);
+        }
+      }
+      if (pubRnnoiseNode) {
+        try {
+          pubRnnoiseNode.disconnect();
+          pubRnnoiseNode.destroy?.();
+        } catch (error) {
+          console.warn('Failed to close RNNoise node:', error);
+        }
+      }
+      pubDenoiseSource = null;
+      pubDenoiseDestination = null;
+      pubRnnoiseNode = null;
+    }
+
+    async function applyNoiseSuppression(rawStream) {
+      if (!isRnnoiseEnabled()) {
+        updateRnnoiseStatus('Using browser noise suppression.');
+        resetDenoiseGraph();
+        return rawStream;
+      }
+
+      if (typeof AudioWorkletNode === 'undefined') {
+        updateRnnoiseStatus('RNNoise unavailable in this browser (AudioWorklet not supported).');
+        return rawStream;
+      }
+
+      try {
+        if (!pubAudioContext || pubAudioContext.state === 'closed') {
+          pubAudioContext = new (window.AudioContext || window.webkitAudioContext)();
+          pubRnnoiseWorkletLoaded = false;
+        }
+        if (pubAudioContext.state === 'suspended') {
+          await pubAudioContext.resume();
+        }
+
+        const { RnnoiseWorkletNode, loadRnnoise } = await loadRnnoiseModule();
+        if (!pubRnnoiseWorkletLoaded) {
+          await pubAudioContext.audioWorklet.addModule(`${rnnoiseAssetBase}/rnnoise/workletProcessor.js`);
+          pubRnnoiseWorkletLoaded = true;
+        }
+
+        const wasmBinary = await loadRnnoise({
+          url: `${rnnoiseAssetBase}/rnnoise.wasm`,
+          simdUrl: `${rnnoiseAssetBase}/rnnoise_simd.wasm`
+        });
+
+        resetDenoiseGraph();
+        pubDenoiseSource = pubAudioContext.createMediaStreamSource(rawStream);
+        pubRnnoiseNode = new RnnoiseWorkletNode(pubAudioContext, {
+          wasmBinary,
+          maxChannels: 1
+        });
+        pubDenoiseDestination = pubAudioContext.createMediaStreamDestination();
+        pubDenoiseSource.connect(pubRnnoiseNode);
+        pubRnnoiseNode.connect(pubDenoiseDestination);
+
+        updateRnnoiseStatus('RNNoise suppression enabled.');
+        return pubDenoiseDestination.stream;
+      } catch (error) {
+        console.warn('RNNoise initialization failed. Falling back to browser suppression.', error);
+        updateRnnoiseStatus('RNNoise failed to initialize, using browser suppression.');
+        resetDenoiseGraph();
+        return rawStream;
+      }
     }
 
     async function waitForTranscriptLib(timeoutMs = 10000) {
@@ -746,6 +877,21 @@
 
         // Add change listener for switching microphone during broadcast
         audioSourceSelect.addEventListener('change', handleAudioSourceChange);
+
+        const rnnoiseToggle = document.getElementById('rnnoiseToggle');
+        if (rnnoiseToggle && !rnnoiseToggle.dataset.listenerAttached) {
+          rnnoiseToggle.addEventListener('change', () => {
+            if (pubProducer) {
+              showError('Restart broadcasting to apply RNNoise changes.');
+            }
+            updateRnnoiseStatus(
+              rnnoiseToggle.checked
+                ? 'RNNoise will be used for the next microphone capture.'
+                : 'Using browser noise suppression.'
+            );
+          });
+          rnnoiseToggle.dataset.listenerAttached = 'true';
+        }
       } catch (error) {
         console.error('Error loading audio devices:', error);
         showError('Error loading audio devices: ' + error.message);
@@ -790,27 +936,27 @@
           });
           pubAudioStream = null;
         }
+        if (pubRawAudioStream) {
+          pubRawAudioStream.getTracks().forEach(track => track.stop());
+          pubRawAudioStream = null;
+        }
+        resetDenoiseGraph();
 
         // Small delay to allow OS to release the microphone
         await new Promise(resolve => setTimeout(resolve, 100));
 
         // Get new stream from selected device
-        const newStream = await navigator.mediaDevices.getUserMedia({
-          audio: {
-            deviceId: { exact: newDeviceId },
-            echoCancellation: true,
-            noiseSuppression: true,
-            autoGainControl: true
-          }
-        });
-        const newTrack = newStream.getAudioTracks()[0];
+        const newStream = await navigator.mediaDevices.getUserMedia({ audio: getMicAudioConstraints(newDeviceId) });
+        pubRawAudioStream = newStream;
+        const processedStream = await applyNoiseSuppression(newStream);
+        const newTrack = processedStream.getAudioTracks()[0];
         console.log('New track obtained:', newTrack.label);
 
-        pubAudioStream = newStream;
+        pubAudioStream = processedStream;
 
         // Update audio meter with new source
         if (pubAudioContext && pubAudioMeter) {
-          pubAudioSource = pubAudioContext.createMediaStreamSource(newStream);
+          pubAudioSource = pubAudioContext.createMediaStreamSource(processedStream);
           pubAudioSource.connect(pubAudioMeter);
         }
 
@@ -1286,24 +1432,16 @@
         lastAudioDeviceId = audioSourceId || null;
 
         // Get microphone access (use selected device when available)
-        const audioConstraints = audioSourceId
-          ? {
-            deviceId: { exact: audioSourceId },
-            echoCancellation: true,
-            noiseSuppression: true,
-            autoGainControl: true
-          }
-          : true;
-
         const micRequest = navigator.mediaDevices.getUserMedia({
-          audio: audioConstraints
+          audio: getMicAudioConstraints(audioSourceId)
         });
         const micTimeout = new Promise((_, reject) =>
           setTimeout(() => reject(new Error('Microphone request timed out')), 5000)
         );
 
         try {
-          pubAudioStream = await Promise.race([micRequest, micTimeout]);
+          pubRawAudioStream = await Promise.race([micRequest, micTimeout]);
+          pubAudioStream = await applyNoiseSuppression(pubRawAudioStream);
         } catch (micErr) {
           console.warn('Using synthetic fallback audio stream:', micErr.message);
           if (pubSyntheticAudioContext && pubSyntheticAudioContext.state !== 'closed') {
@@ -1315,6 +1453,7 @@
           pubSyntheticOscillator.frequency.value = 440;
           pubSyntheticOscillator.connect(destination);
           pubSyntheticOscillator.start();
+          pubRawAudioStream = destination.stream;
           pubAudioStream = destination.stream;
         }
 
@@ -1425,6 +1564,11 @@
         pubAudioStream.getTracks().forEach(track => track.stop());
         pubAudioStream = null;
       }
+      if (pubRawAudioStream) {
+        pubRawAudioStream.getTracks().forEach(track => track.stop());
+        pubRawAudioStream = null;
+      }
+      resetDenoiseGraph();
 
       if (pubSyntheticOscillator) {
         try {
@@ -1461,6 +1605,7 @@
           pubAudioContext.close();
         }
         pubAudioContext = null;
+        pubRnnoiseWorkletLoaded = false;
       }
 
       // Clear meter update interval

--- a/src/public/room-publish.html
+++ b/src/public/room-publish.html
@@ -453,11 +453,11 @@
             <option value="">Select audio source</option>
           </select>
           <label class="audio-option-row">
-            <span>RNNoise suppression (beta)</span>
+            <span>Enable Noise suppression (beta)</span>
             <input type="checkbox" id="rnnoiseToggle">
           </label>
           <div class="audio-option-help" id="rnnoiseStatus">
-            Uses browser noise suppression by default. Enable RNNoise for stronger suppression.
+            Noise suppression disabled.
           </div>
         </div>
 
@@ -590,7 +590,7 @@
       return {
         ...(audioSourceId ? { deviceId: { exact: audioSourceId } } : {}),
         echoCancellation: true,
-        noiseSuppression: !isRnnoiseEnabled(),
+        noiseSuppression: false,
         autoGainControl: true
       };
     }
@@ -646,13 +646,21 @@
 
     async function applyNoiseSuppression(rawStream) {
       if (!isRnnoiseEnabled()) {
-        updateRnnoiseStatus('Using browser noise suppression.');
+        updateRnnoiseStatus('Noise suppression disabled.');
         resetDenoiseGraph();
         return rawStream;
       }
 
       if (typeof AudioWorkletNode === 'undefined') {
-        updateRnnoiseStatus('RNNoise unavailable in this browser (AudioWorklet not supported).');
+        const track = rawStream.getAudioTracks()[0];
+        if (track) {
+          try {
+            await track.applyConstraints({ noiseSuppression: true });
+          } catch (error) {
+            console.warn('Failed to enable browser noise suppression fallback:', error);
+          }
+        }
+        updateRnnoiseStatus('Noise suppression enabled.');
         return rawStream;
       }
 
@@ -686,11 +694,19 @@
         pubDenoiseSource.connect(pubRnnoiseNode);
         pubRnnoiseNode.connect(pubDenoiseDestination);
 
-        updateRnnoiseStatus('RNNoise suppression enabled.');
+        updateRnnoiseStatus('Noise suppression enabled.');
         return pubDenoiseDestination.stream;
       } catch (error) {
         console.warn('RNNoise initialization failed. Falling back to browser suppression.', error);
-        updateRnnoiseStatus('RNNoise failed to initialize, using browser suppression.');
+        const track = rawStream.getAudioTracks()[0];
+        if (track) {
+          try {
+            await track.applyConstraints({ noiseSuppression: true });
+          } catch (applyError) {
+            console.warn('Failed to enable browser noise suppression fallback:', applyError);
+          }
+        }
+        updateRnnoiseStatus('Noise suppression enabled.');
         resetDenoiseGraph();
         return rawStream;
       }
@@ -880,14 +896,16 @@
 
         const rnnoiseToggle = document.getElementById('rnnoiseToggle');
         if (rnnoiseToggle && !rnnoiseToggle.dataset.listenerAttached) {
-          rnnoiseToggle.addEventListener('change', () => {
+          rnnoiseToggle.addEventListener('change', async () => {
             if (pubProducer) {
-              showError('Restart broadcasting to apply RNNoise changes.');
+              const audioSourceSelect = document.getElementById('audioSource');
+              const selectedDeviceId = audioSourceSelect ? audioSourceSelect.value : '';
+              await restartMicrophoneCapture(selectedDeviceId, 'Applying RNNoise setting...');
             }
             updateRnnoiseStatus(
               rnnoiseToggle.checked
-                ? 'RNNoise will be used for the next microphone capture.'
-                : 'Using browser noise suppression.'
+                ? 'Noise suppression enabled.'
+                : 'Noise suppression disabled.'
             );
           });
           rnnoiseToggle.dataset.listenerAttached = 'true';
@@ -896,6 +914,63 @@
         console.error('Error loading audio devices:', error);
         showError('Error loading audio devices: ' + error.message);
       }
+    }
+
+    // Recreate microphone stream + producer with current settings/device
+    async function restartMicrophoneCapture(deviceId, connectingStatus = 'Switching microphone...') {
+      setStatus(connectingStatus, 'connecting');
+
+      // Close the existing producer first
+      if (pubProducer) {
+        pubProducer.close();
+        pubProducer = null;
+      }
+
+      // Disconnect old audio source from meter
+      if (pubAudioSource) {
+        try {
+          pubAudioSource.disconnect();
+        } catch (e) {
+          console.warn('Error disconnecting old audio source:', e);
+        }
+        pubAudioSource = null;
+      }
+
+      // Stop old audio tracks BEFORE getting new stream
+      // This ensures the old microphone is fully released
+      if (pubAudioStream) {
+        pubAudioStream.getTracks().forEach(track => {
+          track.stop();
+          console.log('Stopped old track:', track.label);
+        });
+        pubAudioStream = null;
+      }
+      if (pubRawAudioStream) {
+        pubRawAudioStream.getTracks().forEach(track => track.stop());
+        pubRawAudioStream = null;
+      }
+      resetDenoiseGraph();
+
+      // Small delay to allow OS to release the microphone
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Get stream from selected device
+      const newStream = await navigator.mediaDevices.getUserMedia({ audio: getMicAudioConstraints(deviceId || undefined) });
+      pubRawAudioStream = newStream;
+      const processedStream = await applyNoiseSuppression(newStream);
+      const newTrack = processedStream.getAudioTracks()[0];
+      console.log('New track obtained:', newTrack.label);
+
+      pubAudioStream = processedStream;
+
+      // Update audio meter with new source
+      if (pubAudioContext && pubAudioMeter) {
+        pubAudioSource = pubAudioContext.createMediaStreamSource(processedStream);
+        pubAudioSource.connect(pubAudioMeter);
+      }
+
+      // Create new producer with new track
+      pubProducer = await pubTransport.produce({ track: newTrack });
     }
 
     // Handle audio source change during broadcast
@@ -908,60 +983,9 @@
       }
 
       console.log('Switching microphone to:', newDeviceId);
-      setStatus('Switching microphone...', 'connecting');
 
       try {
-        // Close the existing producer first
-        if (pubProducer) {
-          pubProducer.close();
-          pubProducer = null;
-        }
-
-        // Disconnect old audio source from meter
-        if (pubAudioSource) {
-          try {
-            pubAudioSource.disconnect();
-          } catch (e) {
-            console.warn('Error disconnecting old audio source:', e);
-          }
-          pubAudioSource = null;
-        }
-
-        // Stop old audio tracks BEFORE getting new stream
-        // This ensures the old microphone is fully released
-        if (pubAudioStream) {
-          pubAudioStream.getTracks().forEach(track => {
-            track.stop();
-            console.log('Stopped old track:', track.label);
-          });
-          pubAudioStream = null;
-        }
-        if (pubRawAudioStream) {
-          pubRawAudioStream.getTracks().forEach(track => track.stop());
-          pubRawAudioStream = null;
-        }
-        resetDenoiseGraph();
-
-        // Small delay to allow OS to release the microphone
-        await new Promise(resolve => setTimeout(resolve, 100));
-
-        // Get new stream from selected device
-        const newStream = await navigator.mediaDevices.getUserMedia({ audio: getMicAudioConstraints(newDeviceId) });
-        pubRawAudioStream = newStream;
-        const processedStream = await applyNoiseSuppression(newStream);
-        const newTrack = processedStream.getAudioTracks()[0];
-        console.log('New track obtained:', newTrack.label);
-
-        pubAudioStream = processedStream;
-
-        // Update audio meter with new source
-        if (pubAudioContext && pubAudioMeter) {
-          pubAudioSource = pubAudioContext.createMediaStreamSource(processedStream);
-          pubAudioSource.connect(pubAudioMeter);
-        }
-
-        // Create new producer with new track
-        pubProducer = await pubTransport.produce({ track: newTrack });
+        await restartMicrophoneCapture(newDeviceId, 'Switching microphone...');
 
         console.log('Microphone switched successfully - new producer created');
         setStatus('Broadcasting', 'broadcasting');

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,21 @@ function getPublicDir() {
   return devPath;
 }
 
+function getRnnoiseAssetsDir() {
+  const candidatePaths = [
+    path.join(__dirname, '..', 'node_modules', '@sapphi-red', 'web-noise-suppressor', 'dist'),
+    path.join(process.cwd(), 'node_modules', '@sapphi-red', 'web-noise-suppressor', 'dist')
+  ];
+
+  for (const candidate of candidatePaths) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 // Create fastify instance
 const fastify = Fastify({
   logger: true
@@ -100,6 +115,16 @@ fastify.register(fastifyStatic, {
   root: publicDir,
   prefix: '/' // optional: default '/'
 });
+
+const rnnoiseAssetsDir = getRnnoiseAssetsDir();
+if (rnnoiseAssetsDir) {
+  fastify.register(fastifyStatic, {
+    root: rnnoiseAssetsDir,
+    prefix: '/vendor/web-noise-suppressor/'
+  });
+} else {
+  console.warn('RNNoise assets not found in node_modules. Publisher RNNoise toggle will fallback to browser suppression.');
+}
 
 // Register WebSocket plugin
 fastify.register(fastifyWebsocket, {

--- a/src/server.js
+++ b/src/server.js
@@ -120,7 +120,8 @@ const rnnoiseAssetsDir = getRnnoiseAssetsDir();
 if (rnnoiseAssetsDir) {
   fastify.register(fastifyStatic, {
     root: rnnoiseAssetsDir,
-    prefix: '/vendor/web-noise-suppressor/'
+    prefix: '/vendor/web-noise-suppressor/',
+    decorateReply: false
   });
 } else {
   console.warn('RNNoise assets not found in node_modules. Publisher RNNoise toggle will fallback to browser suppression.');


### PR DESCRIPTION
### Motivation

- Improve publisher audio quality by adding an optional RNNoise-based noise suppression path in addition to the browser's built-in suppression.
- Provide a UI toggle so publishers can enable stronger suppression on supported browsers while keeping a safe fallback.
- Make RNNoise web assets available from the server so the client can dynamically load the worklet and WASM files.

### Description

- Added `@sapphi-red/web-noise-suppressor` to `package.json` and updated `package-lock.json` to include the new dependency.
- Updated `src/public/room-publish.html` to add a RNNoise toggle UI and status element, and implemented client-side logic including `isRnnoiseEnabled`, `getMicAudioConstraints`, `loadRnnoiseModule`, `applyNoiseSuppression`, `resetDenoiseGraph`, and wiring to use a raw media stream (`pubRawAudioStream`) and a processed stream (`pubAudioStream`).
- Enhanced microphone switching and broadcast lifecycle handling to stop raw tracks, reset the denoise graph, and recreate processors when devices change or broadcasting stops.
- Added server-side static asset serving logic in `src/server.js` via `getRnnoiseAssetsDir()` and `fastify.register(fastifyStatic, { prefix: '/vendor/web-noise-suppressor/' })`, with a console warning when assets cannot be found.
- Implemented feature detection and safe fallbacks: checks for `AudioWorkletNode`, worklet/WASM loading with graceful fallback to browser suppression, and robust cleanup of AudioNodes and contexts.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2f60104dc83229a4c71b42f7603cd)